### PR TITLE
feat: Add debug configuration for SQL-Agents:Python:Streamlit

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "SQL-Agents:Python:Streamlit",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "streamlit",
+      "args": ["run", "./src/sql-agents/app.py", "--server.port", "8000"]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a new configuration to the `.vscode/launch.json` file to enable debugging for a Streamlit application in the SQL-Agents project.

* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R1-R12): Added a new debug configuration for running the Streamlit application `sql-agents/app.py` on port 8000 using `debugpy`.